### PR TITLE
Consider all milestones when looking for anything .0

### DIFF
--- a/postplatformrelease.java
+++ b/postplatformrelease.java
@@ -84,7 +84,7 @@ public class postplatformrelease implements Runnable {
                     .filter(m -> m.getTitle().startsWith(getMinorVersion(version) + ".0"))
                     .forEach(m -> {
                         try {
-                            mergedIssues.addAll(repository.getIssues(GHIssueState.CLOSED, m));
+                            mergedIssues.addAll(repository.getIssues(GHIssueState.ALL, m));
                             mergedIssues.addAll(firstFinalIssuesIfNeeded);
                         } catch (IOException e) {
                             System.err.println("Ignored issues for milestone " + m.getTitle());


### PR DESCRIPTION
Apparently if there is an open issue, the milestone is no longer actually considered closed from an API point of view... which is extremely odd and a new behavior...